### PR TITLE
Fix known SDK v2 issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :rubygems do
 end
 
 group :sss do
-  gem 'aws-sdk-v1'
+  gem 'aws-sdk', '>= 2.0.18.pre', '< 2.0.38'
   gem 'mime-types'
 end
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -6,6 +6,8 @@ module DPL
       requires 'aws-sdk'
       requires 'mime-types'
 
+      attr_reader :s3_options
+
       def api
         @api ||= ::Aws::S3::Resource.new(s3_options)
       end
@@ -27,12 +29,13 @@ module DPL
       end
 
       def s3_options
-        s3_options = {
+        return @s3_options if @s3_options
+        @s3_options = {
           region:      options[:region] || 'us-east-1',
           credentials: ::Aws::Credentials.new(access_key_id, secret_access_key)
         }
-        s3_options[:endpoint] = endpoint if options[:endpoint]
-        s3_options
+        @s3_options[:endpoint] = endpoint if options[:endpoint]
+        @s3_options
       end
 
       def check_auth
@@ -69,6 +72,8 @@ module DPL
             }
           )
         end
+      rescue => e
+        log "Failed to push\ns3_options: #{s3_options}"
       end
 
       def deploy

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -72,8 +72,6 @@ module DPL
             }
           )
         end
-      rescue => e
-        log "Failed to push\ns3_options: #{s3_options}"
       end
 
       def deploy

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -6,8 +6,6 @@ module DPL
       requires 'aws-sdk'
       requires 'mime-types'
 
-      attr_reader :s3_options
-
       def api
         @api ||= ::Aws::S3::Resource.new(s3_options)
       end
@@ -29,12 +27,10 @@ module DPL
       end
 
       def s3_options
-        return @s3_options if @s3_options
-        @s3_options = {
+        {
           region:      options[:region] || 'us-east-1',
           credentials: ::Aws::Credentials.new(access_key_id, secret_access_key)
         }
-        @s3_options
       end
 
       def check_auth

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -34,7 +34,6 @@ module DPL
           region:      options[:region] || 'us-east-1',
           credentials: ::Aws::Credentials.new(access_key_id, secret_access_key)
         }
-        @s3_options[:endpoint] = endpoint if options[:endpoint]
         @s3_options
       end
 
@@ -90,14 +89,6 @@ module DPL
           {:content_encoding => encoding_for(path)}
         else
           {}
-        end
-      end
-
-      def endpoint
-        if !options[:endpoint].start_with?('http')
-          "https://#{options[:endpoint]}"
-        else
-          options[:endpoint]
         end
       end
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -51,7 +51,7 @@ module DPL
             content_type = MIME::Types.type_for(filename).first.to_s
             opts         = { :content_type => content_type }.merge(encoding_option_for(filename))
             opts[:cache_control] = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]
-            opts[:acl]           = options[:acl] if options[:acl]
+            opts[:acl]           = options[:acl].gsub(/_/, '-') if options[:acl]
             opts[:expires]       = get_option_value_by_filename(options[:expires], filename) if options[:expires]
             unless File.directory?(filename)
               log "uploading %p" % filename

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -4,17 +4,79 @@ require 'dpl/provider/s3'
 
 describe DPL::Provider::S3 do
 
-  before (:each) do
-    AWS.stub!
-  end
-
   subject :provider do
     described_class.new(DummyContext.new, :access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :bucket => 'my-bucket')
   end
 
+  describe '#s3_options' do
+    context 'without region' do
+      example do
+        options = provider.s3_options
+        expect(options[:region]).to eq('us-east-1')
+      end
+    end
+
+    context 'with region' do
+      example do
+        region = 'us-west-1'
+        provider.options.update(:region => region)
+        options = provider.s3_options
+        expect(options[:region]).to eq(region)
+      end
+    end
+
+    context 'without endpoint' do
+      example do
+        options = provider.s3_options
+        expect(options[:endpoint]).to be_nil
+      end
+    end
+
+    context 'with endpoint without protocol' do
+      example do
+        provider.options.update(:endpoint => 's3test.com.s3-website-us-west-2.amazonaws.com')
+        options = provider.s3_options
+        expect(options[:endpoint]).to eq('https://s3test.com.s3-website-us-west-2.amazonaws.com')
+      end
+    end
+
+    context 'with endpoint with protocol' do
+      example do
+        provider.options.update(:endpoint => 'http://s3test.com.s3-website-us-west-2.amazonaws.com')
+        options = provider.s3_options
+        expect(options[:endpoint]).to eq('http://s3test.com.s3-website-us-west-2.amazonaws.com')
+      end
+    end
+  end
+end
+
+describe DPL::Provider::S3 do
+
+  access_key_id = 'qwertyuiopasdfghjklz'
+  secret_access_key = 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz'
+  region = 'us-east-1'
+  bucket = 'my-bucket'
+
+  client_options = {
+    stub_responses: true,
+    region: region,
+    credentials: Aws::Credentials.new(access_key_id, secret_access_key)
+  }
+
+  subject :provider do
+    described_class.new(DummyContext.new, {
+      access_key_id: access_key_id,
+      secret_access_key: secret_access_key,
+      bucket: bucket
+    })
+  end
+
+  before :each do
+    provider.stub(:s3_options).and_return(client_options)
+  end
+
   describe "#check_auth" do
     example do
-      expect(provider).to receive(:setup_auth)
       expect(provider).to receive(:log).with("Logging in with Access Key: ****************jklz")
       provider.check_auth
     end
@@ -32,19 +94,6 @@ describe DPL::Provider::S3 do
       filename = "testfile.file"
 
       expect(provider.upload_path(filename)).to eq("BUILD3/testfile.file")
-    end
-  end
-
-  describe "#setup_auth" do
-    example "Without :region" do
-      expect(AWS).to receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :region => 'us-east-1').once.and_call_original
-      provider.setup_auth
-    end
-    example "With :region" do
-      provider.options.update(:region => 'us-west-2')
-
-      expect(AWS).to receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :region => 'us-west-2').once
-      provider.setup_auth
     end
   end
 
@@ -69,14 +118,14 @@ describe DPL::Provider::S3 do
 
     example "Sends MIME type" do
       expect(Dir).to receive(:glob).and_yield(__FILE__)
-      expect_any_instance_of(AWS::S3::ObjectCollection).to receive(:create).with(anything(), anything(), hash_including(:content_type => 'application/x-ruby'))
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:content_type => 'application/x-ruby'))
       provider.push_app
     end
 
     example "Sets Cache and Expiration" do
       provider.options.update(:cache_control => "max-age=99999999", :expires => "2012-12-21 00:00:00 -0000")
       expect(Dir).to receive(:glob).and_yield(__FILE__)
-      expect_any_instance_of(AWS::S3::ObjectCollection).to receive(:create).with(anything(), anything(), hash_including(:cache_control => 'max-age=99999999', :expires => '2012-12-21 00:00:00 -0000'))
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:cache_control => 'max-age=99999999', :expires => '2012-12-21 00:00:00 -0000'))
       provider.push_app
     end
 
@@ -84,9 +133,8 @@ describe DPL::Provider::S3 do
       option_list = []
       provider.options.update(:cache_control => ["max-age=99999999", "no-cache" => ["foo.html", "bar.txt"], "max-age=9999" => "*.txt"], :expires => ["2012-12-21 00:00:00 -0000", "1970-01-01 00:00:00 -0000" => "*.html"])
       expect(Dir).to receive(:glob).and_yield("foo.html").and_yield("bar.txt").and_yield("baz.js")
-      expect(File).to receive(:read).exactly(3).times.and_return("")
-      allow_any_instance_of(AWS::S3::ObjectCollection).to receive(:create) do |_instance, key, _data, options|
-        option_list << { key: key, options: options }
+      allow_any_instance_of(Aws::S3::Object).to receive(:upload_file) do |obj, _data, options|
+        option_list << { key: obj.key, options: options }
       end
       provider.push_app
       expect(option_list).to match_array([
@@ -99,13 +147,14 @@ describe DPL::Provider::S3 do
     example "Sets ACL" do
       provider.options.update(:acl => "public_read")
       expect(Dir).to receive(:glob).and_yield(__FILE__)
-      expect_any_instance_of(AWS::S3::ObjectCollection).to receive(:create).with(anything(), anything(), hash_including(:acl => "public_read"))
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:acl => "public_read"))
       provider.push_app
     end
 
     example "Sets Website Index Document" do
       provider.options.update(:index_document_suffix => "test/index.html")
       expect(Dir).to receive(:glob).and_yield(__FILE__)
+      expect_any_instance_of(Aws::S3::BucketWebsite).to receive(:put).with(:website_configuration => { :index_document => { :suffix => "test/index.html" } })
       provider.push_app
     end
 
@@ -114,8 +163,7 @@ describe DPL::Provider::S3 do
       provider.options.update(:detect_encoding => true)
       expect(Dir).to receive(:glob).and_yield(path)
       expect(provider).to receive(:`).at_least(1).times.with("file #{path}").and_return('gzip compressed')
-      expect(File).to receive(:read).with(path).and_return("")
-      expect_any_instance_of(AWS::S3::ObjectCollection).to receive(:create).with(anything(), anything(), hash_including(:content_encoding => 'gzip'))
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:content_encoding => 'gzip'))
       provider.push_app
     end
 
@@ -123,18 +171,6 @@ describe DPL::Provider::S3 do
       provider.options.update(:dot_match => true)
       expect(Dir).to receive(:glob).with("**/*", File::FNM_DOTMATCH)
       provider.push_app
-    end
-  end
-
-  describe "#api" do
-    example "Without Endpoint" do
-      expect(AWS::S3).to receive(:new).with(:endpoint => 's3.amazonaws.com')
-      provider.api
-    end
-    example "With Endpoint" do
-      provider.options.update(:endpoint => 's3test.com.s3-website-us-west-2.amazonaws.com')
-      expect(AWS::S3).to receive(:new).with(:endpoint => 's3test.com.s3-website-us-west-2.amazonaws.com')
-      provider.api
     end
   end
 end

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -24,29 +24,6 @@ describe DPL::Provider::S3 do
         expect(options[:region]).to eq(region)
       end
     end
-
-    context 'without endpoint' do
-      example do
-        options = provider.s3_options
-        expect(options[:endpoint]).to be_nil
-      end
-    end
-
-    context 'with endpoint without protocol' do
-      example do
-        provider.options.update(:endpoint => 's3test.com.s3-website-us-west-2.amazonaws.com')
-        options = provider.s3_options
-        expect(options[:endpoint]).to eq('https://s3test.com.s3-website-us-west-2.amazonaws.com')
-      end
-    end
-
-    context 'with endpoint with protocol' do
-      example do
-        provider.options.update(:endpoint => 'http://s3test.com.s3-website-us-west-2.amazonaws.com')
-        options = provider.s3_options
-        expect(options[:endpoint]).to eq('http://s3test.com.s3-website-us-west-2.amazonaws.com')
-      end
-    end
   end
 end
 

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -147,7 +147,7 @@ describe DPL::Provider::S3 do
     example "Sets ACL" do
       provider.options.update(:acl => "public_read")
       expect(Dir).to receive(:glob).and_yield(__FILE__)
-      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:acl => "public_read"))
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:acl => "public-read"))
       provider.push_app
     end
 


### PR DESCRIPTION
This PR addresses 2 known issues with https://github.com/travis-ci/dpl/pull/246.
1. ACL option is correctly set and passed. (`'public_read'` vs `'public-read'`)
2. endpoint flag is deprecated. (Perhaps we can display a deprecation warning, in `check_app`, for example.)
